### PR TITLE
fix network crate + make network_id field required it transactions

### DIFF
--- a/crates/consensus/src/transaction/mod.rs
+++ b/crates/consensus/src/transaction/mod.rs
@@ -23,7 +23,7 @@ pub trait Transaction: any::Any + Send + Sync + 'static {
     fn value(&self) -> U256;
 
     /// Get `chain_id`.
-    fn chain_id(&self) -> Option<ChainId>;
+    fn chain_id(&self) -> ChainId;
 
     /// Get `nonce`.
     fn nonce(&self) -> u64;
@@ -50,17 +50,10 @@ pub trait SignableTransaction<Signature>: Transaction {
     /// Set `chain_id` if it is not already set. Checks that the provided `chain_id` matches the
     /// existing `chain_id` if it is already set, returning `false` if they do not match.
     fn set_chain_id_checked(&mut self, chain_id: ChainId) -> bool {
-        match self.chain_id() {
-            Some(tx_chain_id) => {
-                if tx_chain_id != chain_id {
-                    return false;
-                }
-                self.set_chain_id(chain_id);
-            }
-            None => {
-                self.set_chain_id(chain_id);
-            }
+        if self.chain_id() != chain_id && self.chain_id() != 0 {
+            return false;
         }
+        self.set_chain_id(chain_id);
         true
     }
 

--- a/crates/consensus/src/transaction/typed.rs
+++ b/crates/consensus/src/transaction/typed.rs
@@ -36,7 +36,7 @@ impl TypedTransaction {
 }
 
 impl Transaction for TypedTransaction {
-    fn chain_id(&self) -> Option<alloy_primitives::ChainId> {
+    fn chain_id(&self) -> alloy_primitives::ChainId {
         match self {
             Self::Legacy(tx) => tx.chain_id(),
         }

--- a/crates/network/src/any/mod.rs
+++ b/crates/network/src/any/mod.rs
@@ -1,7 +1,7 @@
 use core::fmt;
 
 use crate::{Network, ReceiptResponse};
-use alloy_consensus::TxType;
+use alloy_consensus::TxLegacy;
 use alloy_eips::eip2718::Eip2718Error;
 use alloy_rpc_types::{
     AnyTransactionReceipt, Header, Transaction, TransactionRequest, WithOtherFields,
@@ -9,45 +9,6 @@ use alloy_rpc_types::{
 
 mod builder;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct AnyTxType(u8);
-
-impl fmt::Display for AnyTxType {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "AnyTxType({})", self.0)
-    }
-}
-
-impl TryFrom<u8> for AnyTxType {
-    type Error = Eip2718Error;
-
-    fn try_from(value: u8) -> Result<Self, Self::Error> {
-        Ok(Self(value))
-    }
-}
-
-impl From<AnyTxType> for u8 {
-    fn from(value: AnyTxType) -> Self {
-        value.0
-    }
-}
-
-impl TryFrom<AnyTxType> for TxType {
-    type Error = Eip2718Error;
-
-    fn try_from(value: AnyTxType) -> Result<Self, Self::Error> {
-        value.0.try_into()
-    }
-}
-
-impl From<TxType> for AnyTxType {
-    fn from(value: TxType) -> Self {
-        Self(value as u8)
-    }
-}
-
-/// Types for a catch-all network.
-///
 /// Essentially just returns the regular Ethereum types + a catch all field.
 /// This [`Network`] should be used only when the network is not known at
 /// compile time.
@@ -57,12 +18,6 @@ pub struct AnyNetwork {
 }
 
 impl Network for AnyNetwork {
-    type TxType = AnyTxType;
-
-    type TxEnvelope = alloy_consensus::TxEnvelope;
-
-    type UnsignedTx = alloy_consensus::TypedTransaction;
-
     type ReceiptEnvelope = alloy_consensus::AnyReceiptEnvelope;
 
     type Header = alloy_consensus::Header;

--- a/crates/network/src/ethereum/mod.rs
+++ b/crates/network/src/ethereum/mod.rs
@@ -12,13 +12,7 @@ pub struct Ethereum {
 }
 
 impl Network for Ethereum {
-    type TxType = alloy_consensus::TxType;
-
-    type TxEnvelope = alloy_consensus::TxEnvelope;
-
-    type UnsignedTx = alloy_consensus::TypedTransaction;
-
-    type ReceiptEnvelope = alloy_consensus::ReceiptEnvelope;
+    type ReceiptEnvelope = alloy_consensus::AnyReceiptEnvelope;
 
     type Header = alloy_consensus::Header;
 

--- a/crates/network/src/ethereum/signer.rs
+++ b/crates/network/src/ethereum/signer.rs
@@ -1,5 +1,5 @@
 use crate::{Network, NetworkSigner, TxSigner};
-use alloy_consensus::{SignableTransaction, TxEnvelope, TypedTransaction};
+use alloy_consensus::{SignableTransaction, Signed, TxLegacy, TypedTransaction};
 use alloy_primitives::IcanAddress;
 use alloy_signer::Signature;
 use async_trait::async_trait;
@@ -98,7 +98,7 @@ impl EthereumSigner {
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl<N> NetworkSigner<N> for EthereumSigner
 where
-    N: Network<UnsignedTx = TypedTransaction, TxEnvelope = TxEnvelope>,
+    N: Network,
 {
     fn default_signer_address(&self) -> IcanAddress {
         self.default
@@ -116,21 +116,9 @@ where
         &self,
         sender: IcanAddress,
         tx: TypedTransaction,
-    ) -> alloy_signer::Result<TxEnvelope> {
+    ) -> alloy_signer::Result<Signed<TxLegacy, Signature>> {
         match tx {
             TypedTransaction::Legacy(mut t) => {
-                let sig = self.sign_transaction_inner(sender, &mut t).await?;
-                Ok(t.into_signed(sig).into())
-            }
-            TypedTransaction::Eip2930(mut t) => {
-                let sig = self.sign_transaction_inner(sender, &mut t).await?;
-                Ok(t.into_signed(sig).into())
-            }
-            TypedTransaction::Eip1559(mut t) => {
-                let sig = self.sign_transaction_inner(sender, &mut t).await?;
-                Ok(t.into_signed(sig).into())
-            }
-            TypedTransaction::Eip4844(mut t) => {
                 let sig = self.sign_transaction_inner(sender, &mut t).await?;
                 Ok(t.into_signed(sig).into())
             }

--- a/crates/network/src/lib.rs
+++ b/crates/network/src/lib.rs
@@ -15,10 +15,11 @@
 #![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
-use alloy_consensus::TxReceipt;
+use alloy_consensus::{SignableTransaction, TxReceipt};
 use alloy_eips::eip2718::{Eip2718Envelope, Eip2718Error};
 use alloy_json_rpc::RpcObject;
 use alloy_primitives::IcanAddress;
+use alloy_signer::Signature;
 use core::fmt::{Debug, Display};
 
 mod transaction;
@@ -53,28 +54,6 @@ pub trait ReceiptResponse {
 pub trait Network: Debug + Clone + Copy + Sized + Send + Sync + 'static {
     // -- Consensus types --
 
-    /// The network transaction type enum.
-    ///
-    /// This should be a simple `#[repr(u8)]` enum, and as such has strict type
-    /// bounds for better use in error messages, assertions etc.
-    type TxType: Into<u8>
-        + PartialEq
-        + Eq
-        + TryFrom<u8, Error = Eip2718Error>
-        + Debug
-        + Display
-        + Clone
-        + Copy
-        + Send
-        + Sync
-        + 'static;
-
-    /// The network transaction envelope type.
-    type TxEnvelope: Eip2718Envelope + Debug;
-
-    /// An enum over the various transaction types.
-    type UnsignedTx: From<Self::TxEnvelope>;
-
     /// The network receipt envelope type.
     type ReceiptEnvelope: Eip2718Envelope + TxReceipt;
 
@@ -84,11 +63,7 @@ pub trait Network: Debug + Clone + Copy + Sized + Send + Sync + 'static {
     // -- JSON RPC types --
 
     /// The JSON body of a transaction request.
-    type TransactionRequest: RpcObject
-        + TransactionBuilder<Self>
-        + Debug
-        + From<Self::TxEnvelope>
-        + From<Self::UnsignedTx>;
+    type TransactionRequest: RpcObject + TransactionBuilder<Self> + Debug;
 
     /// The JSON body of a transaction response.
     type TransactionResponse: RpcObject;

--- a/crates/rpc-types/src/eth/transaction/mod.rs
+++ b/crates/rpc-types/src/eth/transaction/mod.rs
@@ -90,8 +90,8 @@ pub struct Transaction {
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
     pub signature: Option<Signature>,
     /// The network id of the transaction.
-    #[serde(default, with = "alloy_serde::u64_opt_via_ruint")]
-    pub network_id: Option<u64>,
+    #[serde(default, with = "alloy_serde::u64_via_ruint")]
+    pub network_id: u64,
     /// Contains the blob hashes for eip-4844 transactions.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub blob_versioned_hashes: Option<Vec<B256>>,
@@ -213,7 +213,7 @@ mod tests {
             energy: 10,
             input: Bytes::from(vec![11, 12, 13]),
             signature: Some(Signature::from_str("0x000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000").unwrap()),
-            network_id: Some(17),
+            network_id: 17,
             blob_versioned_hashes: None,
             // access_list: None,
             transaction_type: Some(20),
@@ -245,7 +245,7 @@ mod tests {
         let serialized = serde_json::to_string(&transaction).unwrap();
         assert_eq!(
             serialized,
-            r#"{"hash":"0x0000000000000000000000000000000000000000000000000000000000000001","nonce":"0x2","blockHash":null,"blockNumber":null,"transactionIndex":null,"from":"0x00000000000000000000000000000000000000000006","to":null,"value":"0x8","energy":"0xa","input":"0x0b0c0d","networkId":null}"#
+            r#"{"hash":"0x0000000000000000000000000000000000000000000000000000000000000001","nonce":"0x2","blockHash":null,"blockNumber":null,"transactionIndex":null,"from":"0x00000000000000000000000000000000000000000006","to":null,"value":"0x8","energy":"0xa","input":"0x0b0c0d","networkId":"0x0"}"#
         );
         let deserialized: Transaction = serde_json::from_str(&serialized).unwrap();
         assert_eq!(transaction, deserialized);

--- a/crates/rpc-types/src/eth/transaction/request.rs
+++ b/crates/rpc-types/src/eth/transaction/request.rs
@@ -65,12 +65,8 @@ pub struct TransactionRequest {
     )]
     pub nonce: Option<u64>,
     /// The chain ID for the transaction.
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        with = "alloy_serde::num::u64_opt_via_ruint"
-    )]
-    pub network_id: Option<ChainId>,
+    #[serde(default, with = "alloy_serde::num::u64_via_ruint")]
+    pub network_id: ChainId,
     /// An EIP-2930 access list, which lowers cost for accessing accounts and storages in the list. See [EIP-2930](https://eips.ethereum.org/EIPS/eip-2930) for more information.
     // #[serde(default, skip_serializing_if = "Option::is_none")]
     // pub access_list: Option<AccessList>,
@@ -424,17 +420,17 @@ mod tests {
 
         let network_id_as_num = format!(r#"{{"networkId": {} }}"#, network_id);
         let req1 = serde_json::from_str::<TransactionRequest>(&network_id_as_num).unwrap();
-        assert_eq!(req1.network_id.unwrap(), network_id);
+        assert_eq!(req1.network_id, network_id);
 
         let network_id_as_hex = format!(r#"{{"networkId": "0x{:x}" }}"#, network_id);
         let req2 = serde_json::from_str::<TransactionRequest>(&network_id_as_hex).unwrap();
-        assert_eq!(req2.network_id.unwrap(), network_id);
+        assert_eq!(req2.network_id, network_id);
     }
 
     #[test]
     fn serde_empty() {
         let tx = TransactionRequest::default();
         let serialized = serde_json::to_string(&tx).unwrap();
-        assert_eq!(serialized, "{}");
+        assert_eq!(serialized, "{\"networkId\":\"0x0\"}");
     }
 }

--- a/crates/signer-wallet/src/private_key.rs
+++ b/crates/signer-wallet/src/private_key.rs
@@ -19,7 +19,7 @@ impl Wallet<SigningKey> {
     #[inline]
     pub fn from_signing_key(signer: SigningKey, network_id: u64) -> Self {
         let address = secret_key_to_address(&signer, network_id);
-        Self::new_with_signer(signer, address, Some(network_id))
+        Self::new_with_signer(signer, address, network_id)
     }
 
     // /// Creates a new Wallet instance from a raw scalar serialized as a [`B256`] byte array.
@@ -349,7 +349,7 @@ mod tests {
 
         let wallet_sk: Wallet<SigningKey> = Wallet::<SigningKey>::from_signing_key(sk, 1);
         assert_eq!(wallet_sk.address, cAddress!("cb94b3ccb2368c2d4b7a5e1c9c773d42eda1721683b3"));
-        assert_eq!(wallet_sk.network_id, Some(1));
+        assert_eq!(wallet_sk.network_id, 1);
         assert_eq!(wallet_sk.signer, SigningKey::from_bytes(key_slice).unwrap());
 
         let wallet_slice = Wallet::from_slice(&key_slice[..], 1).unwrap();

--- a/crates/signer/README.md
+++ b/crates/signer/README.md
@@ -56,7 +56,7 @@ let mut tx = TxLegacy {
     nonce: 0,
     energy_price: 21_000_000_000,
     input: bytes!(),
-    network_id: Some(1),
+    network_id: 1,
 };
 
 // Sign it.

--- a/crates/signer/src/lib.rs
+++ b/crates/signer/src/lib.rs
@@ -35,12 +35,12 @@ macro_rules! sign_transaction_with_network_id {
     //    sign: lazy Signature,
     // )
     ($signer:expr, $tx:expr, $sign:expr) => {{
-        if let Some(network_id) = $signer.network_id() {
+        if let network_id = $signer.network_id() {
             if !$tx.set_chain_id_checked(network_id) {
                 return Err(alloy_signer::Error::TransactionNetworkIdMismatch {
                     signer: network_id,
                     // we can only end up here if the tx has a network id
-                    tx: $tx.chain_id().unwrap(),
+                    tx: $tx.chain_id(),
                 });
             }
         }

--- a/crates/signer/src/signer.rs
+++ b/crates/signer/src/signer.rs
@@ -62,16 +62,16 @@ pub trait Signer<Sig = Signature> {
     fn address(&self) -> IcanAddress;
 
     /// Returns the signer's network ID.
-    fn network_id(&self) -> Option<ChainId>;
+    fn network_id(&self) -> ChainId;
 
     /// Sets the signer's network ID.
-    fn set_network_id(&mut self, network_id: Option<ChainId>);
+    fn set_network_id(&mut self, network_id: ChainId);
 
     /// Sets the signer's network ID and returns `self`.
     #[inline]
     #[must_use]
     #[auto_impl(keep_default_for(&mut, Box))]
-    fn with_network_id(mut self, network_id: Option<ChainId>) -> Self
+    fn with_network_id(mut self, network_id: ChainId) -> Self
     where
         Self: Sized,
     {
@@ -129,7 +129,7 @@ pub trait SignerSync<Sig = Signature> {
     }
 
     /// Returns the signer's network ID.
-    fn network_id_sync(&self) -> Option<ChainId>;
+    fn network_id_sync(&self) -> ChainId;
 }
 
 #[cfg(test)]
@@ -184,7 +184,7 @@ mod tests {
                 Err(Error::UnsupportedOperation(UnsupportedSignerOperation::SignHash))
             );
 
-            assert_eq!(s.network_id(), None);
+            assert_eq!(s.network_id(), 0);
         }
 
         fn test_unsized_unimplemented_signer_sync<S: SignerSync + ?Sized>(s: &S) {
@@ -207,7 +207,7 @@ mod tests {
                 Err(Error::UnsupportedOperation(UnsupportedSignerOperation::SignHash))
             );
 
-            assert_eq!(s.network_id_sync(), None);
+            assert_eq!(s.network_id_sync(), 0);
         }
 
         struct UnimplementedSigner;
@@ -223,11 +223,11 @@ mod tests {
                 IcanAddress::ZERO
             }
 
-            fn network_id(&self) -> Option<ChainId> {
-                None
+            fn network_id(&self) -> ChainId {
+                0
             }
 
-            fn set_network_id(&mut self, _network_id: Option<ChainId>) {}
+            fn set_network_id(&mut self, _network_id: ChainId) {}
         }
 
         impl SignerSync for UnimplementedSigner {
@@ -235,8 +235,8 @@ mod tests {
                 Err(Error::UnsupportedOperation(UnsupportedSignerOperation::SignHash))
             }
 
-            fn network_id_sync(&self) -> Option<ChainId> {
-                None
+            fn network_id_sync(&self) -> ChainId {
+                0
             }
         }
 


### PR DESCRIPTION
Fix network crate + tests.
Also made network_id field u64 instead of Option<u64> in tx structs. In gocore networkId is required for sigining transaction